### PR TITLE
Don't log opaque SSL pointer fields

### DIFF
--- a/ngx_http_upstream_jdomain.c
+++ b/ngx_http_upstream_jdomain.c
@@ -619,9 +619,8 @@ ngx_http_upstream_set_jdomain_peer_session(ngx_peer_connection_t *pc, void *data
 
   rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
-  ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                 "set session: %p:%d",
-                 ssl_session, ssl_session ? ssl_session->references : 0);
+  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                 "set session: %p", ssl_session);
 
   return rc;
 }
@@ -651,8 +650,8 @@ ngx_http_upstream_save_jdomain_peer_session(ngx_peer_connection_t *pc, void *dat
     return;
   }
 
-  ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0, 
-                 "save session: %p:%d", ssl_session, ssl_session->references);
+  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0, 
+                 "save session: %p", ssl_session);
 
   peer = &urpd->conf->peers[urpd->current];
 
@@ -660,9 +659,8 @@ ngx_http_upstream_save_jdomain_peer_session(ngx_peer_connection_t *pc, void *dat
   peer->ssl_session = ssl_session;
 
   if (old_ssl_session) {
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "old session: %p:%d",
-                   old_ssl_session, old_ssl_session->references);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "old session: %p", old_ssl_session);
 
     ngx_ssl_free_session(old_ssl_session);
   }


### PR DESCRIPTION
Encapsulated in newer versions of OpenSSL